### PR TITLE
Bump graceful-fs dependency to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "batcher": "0.0.2",
-    "graceful-fs": "~1.2.2",
+    "graceful-fs": "~2.0.0",
     "readdirp": "~0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
There was a fairly large rewrite recently, adding a couple more guards as well (process.cwd(), etc). Thanks!
